### PR TITLE
Added "${mypackage}" to MainActivity.java

### DIFF
--- a/src/android/MainActivity.java
+++ b/src/android/MainActivity.java
@@ -17,7 +17,7 @@
        under the License.
  */
 
-package uk.co.reallysmall.leaveyouregosatthedoor;
+package ${mypackage};
 
 /** extends CordovaActivity */
 

--- a/src/android/uk/co/reallysmall/cordova/plugin/fragment/CordovaFragment.java
+++ b/src/android/uk/co/reallysmall/cordova/plugin/fragment/CordovaFragment.java
@@ -119,7 +119,9 @@ public class CordovaFragment extends Fragment {
     }
 
     public void setContentView(View contentView) {
-        this.contentView = contentView;
+        FrameLayout frame = new FrameLayout(this.getActivity().getBaseContext());
+        frame.addView(contentView);
+        this.contentView = frame;
     }
 
     @Override


### PR DESCRIPTION
The script afterPluginInstall.js fails due to the missing package name "${mypackage}" in the MainActivity.java.
I replaced the package name with the variable name and now the script works well!